### PR TITLE
Remove stray line from the example loader script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Alternatively add the shim dynamically with something like this. This has the dr
     <link rel="stylesheet" href="app.css">
     <script>
         var cssVarSupport = window.CSS && CSS.supports && CSS.supports('--a', 0);
-        cssVarSupport = false;
         if (!cssVarSupport) {
             var cssVarScript = document.createElement('script');
             cssVarScript.src = 'css-var-shim.js';


### PR DESCRIPTION
Remove a stray line which causes the shim to always be used even if the browser supports CSS variables.